### PR TITLE
Update Kiro CLI version command path

### DIFF
--- a/workshop-building-agentic-ai-platform/static/cfn/code-editor.yaml
+++ b/workshop-building-agentic-ai-platform/static/cfn/code-editor.yaml
@@ -996,7 +996,7 @@ Resources:
                     sudo -u ${CodeEditorUser} /tmp/kirocli/install.sh 2>&1
                     rm -rf /tmp/kirocli /tmp/kirocli.zip
                 - echo "Kiro CLI installed. Checking configuration"
-                - !Sub sudo -i -u ${CodeEditorUser} kiro-cli --version
+                - !Sub sudo -i -u ${CodeEditorUser} /usr/local/bin/kiro-cli --version
           - name: ConfigureKiroCliCustomAgent
             action: aws:runShellScript
             inputs:


### PR DESCRIPTION
Update Kiro CLI version command path to address kiro-cli 2.12.0 update.

*Issue #, if available:* NA

*Description of changes:*
Fix workshop deployment Error.
Update Kiro CLI version command path to address kiro-cli 2.12.0 update.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
