### PR TITLE
chore(self-service): pin ruff and format the markdown blocks 0.16 now checks

### DIFF
--- a/Agentic-ai-self-service/backend/pyproject.toml
+++ b/Agentic-ai-self-service/backend/pyproject.toml
@@ -24,6 +24,11 @@ dev = [
     "httpx>=0.28.0",
     "moto[dynamodb]>=5.0.0",
     "requests>=2.31.0",
+    # Exact pin, unlike everything else here: a formatter's output changes between
+    # minor releases, so `>=` would mean `ruff format --check` locally and in CI
+    # could disagree while both were "satisfied". Must match the `version:` pinned
+    # on the ruff-action steps in .github/workflows/ci.yml.
+    "ruff==0.16.4",
 ]
 deploy = [
     "bedrock-agentcore-starter-toolkit",

--- a/Agentic-ai-self-service/docs/DEPLOYMENT_INTERNALS.md
+++ b/Agentic-ai-self-service/docs/DEPLOYMENT_INTERNALS.md
@@ -342,16 +342,14 @@ Each tool has an MCP-compliant schema registered in `GATEWAY_TOOL_SCHEMAS`:
 
 ```python
 GATEWAY_TOOL_SCHEMAS = {
-    'duckduckgo_search': {
-        'name': 'duckduckgo_search',
-        'description': 'Search the web using DuckDuckGo...',
-        'inputSchema': {
-            'type': 'object',
-            'properties': {
-                'query': {'type': 'string', 'description': 'The search query'}
-            },
-            'required': ['query']
-        }
+    "duckduckgo_search": {
+        "name": "duckduckgo_search",
+        "description": "Search the web using DuckDuckGo...",
+        "inputSchema": {
+            "type": "object",
+            "properties": {"query": {"type": "string", "description": "The search query"}},
+            "required": ["query"],
+        },
     },
     # ... wikipedia_search, weather_api, web_page_fetcher
 }

--- a/Agentic-ai-self-service/docs/MCP_CATALOG.md
+++ b/Agentic-ai-self-service/docs/MCP_CATALOG.md
@@ -98,17 +98,23 @@ Airtable, Zoom, Canva**.
 from app.services.gateway_deployer import deploy_external_mcp_target
 from app.services.mcp_catalog import get_mcp_server
 
-entry = get_mcp_server("aws-knowledge")           # Tier 1, no creds
+entry = get_mcp_server("aws-knowledge")  # Tier 1, no creds
 deploy_external_mcp_target(agentcore_ctrl, gateway_id=gid, catalog_entry=entry)
 
-entry = get_mcp_server("exa")                      # Tier 2, static key
-deploy_external_mcp_target(agentcore_ctrl, gateway_id=gid, catalog_entry=entry,
-                           secret_arn="<secrets-manager-arn-holding-the-key>")
+entry = get_mcp_server("exa")  # Tier 2, static key
+deploy_external_mcp_target(
+    agentcore_ctrl, gateway_id=gid, catalog_entry=entry, secret_arn="<secrets-manager-arn-holding-the-key>"
+)
 
-entry = get_mcp_server("databricks")               # Tier 3, machine OAuth
-deploy_external_mcp_target(agentcore_ctrl, gateway_id=gid, catalog_entry=entry,
-                           endpoint="https://myws.cloud.databricks.com/api/2.0/mcp/sql",
-                           oauth_provider_arn="<oauth-provider-arn>", oauth_scopes=["sql"])
+entry = get_mcp_server("databricks")  # Tier 3, machine OAuth
+deploy_external_mcp_target(
+    agentcore_ctrl,
+    gateway_id=gid,
+    catalog_entry=entry,
+    endpoint="https://myws.cloud.databricks.com/api/2.0/mcp/sql",
+    oauth_provider_arn="<oauth-provider-arn>",
+    oauth_scopes=["sql"],
+)
 ```
 
 ## Live verification


### PR DESCRIPTION
Follow-up to #16 (already merged). That PR landed the Agent Registry GA migration; this carries the toolchain half, which arrived a few minutes too late to be included.

## Why

ruff 0.16 promoted formatting of Python code blocks **inside markdown** from experimental to on-by-default. `ruff format --check .` on 0.15.x skipped markdown entirely; on 0.16.x it reformats two doc snippets here (quote style and line wrapping — cosmetic, no snippet's meaning moved).

This surfaced as a red `Python lint & format` job on the sibling repo, citing `docs/` files the author never touched. Root cause was the *gate*, not the code: `ruff-action` derives its version from the nearest `pyproject.toml`, and neither repo has one at the root (the Python projects are `backend/` and `infra/`), so it logged *"Could not find pyproject.toml. Using latest version."* The job's verdict depended on Astral's release date rather than on the commit under test, and a contributor's local `ruff format --check` no longer predicted CI.

## What's here

- `ruff==0.16.4` in `backend/pyproject.toml` dev extras. Exact pin, unlike the `>=` used for everything else in that list: formatter output changes between minor releases, so `>=` would let local and CI disagree while both were satisfied. Dependabot already watches `/backend`, so bumps arrive as a reviewable PR rather than an overnight red build.
- The two doc snippets reformatted.

This subtree has no ruff workflow of its own, so nothing here was failing. The pin is carried anyway because these two trees are maintained as byte-identical copies and silent divergence between them is the thing that actually causes trouble later. The corresponding CI pin (`version: 0.16.4` on both ruff-action steps) lives in the sibling repo, which is where the workflow file is: aws-samples/sample-agentcore-lowcode-nocode#60.

## Verified

ruff 0.16.4: `check .` → all checks passed; `format --check .` → 272 files already formatted. All three files byte-identical to their counterparts in the sibling repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)